### PR TITLE
comparator accepts return boolean value

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,12 @@ module.exports = function checksort (array, comparator) {
   comparator = comparator || defaultComparator
 
   for (var i = 1, length = array.length; i < length; ++i) {
-    if (comparator(array[i - 1], array[i]) > 0) return false
+    var result = comparator(array[i - 1], array[i])
+
+    if ((typeof result === 'boolean' && !result) ||
+       (comparator(array[i - 1], array[i]) > 0)) {
+      return false
+    }
   }
 
   return true


### PR DESCRIPTION
So we can define a comparator like this:
```js
var isSorted = require('is-sorted')

console.log(isSorted([1, 3, 5, 7, 9], (a, b) => b - a === 2))   // true
console.log(isSorted([2, 4, 8, 16, 32], (a, b) => b / a === 2)) // true
```